### PR TITLE
remove unused param causing memory leak

### DIFF
--- a/core/src/main/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
+++ b/core/src/main/scala/akka/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
@@ -140,12 +140,11 @@ class JdbcDurableStateStore[A](
       terminateAfterOffset: Option[Long]): Source[DurableStateChange[A], NotUsed] = {
 
     val batchSize = durableStateConfig.batchSize
-    val startingOffsets = List.empty[Long]
     implicit val askTimeout: Timeout = Timeout(durableStateConfig.stateSequenceConfig.askTimeout)
 
     Source
-      .unfoldAsync[(Long, FlowControl, List[Long]), Seq[DurableStateChange[A]]]((offset, Continue, startingOffsets)) {
-        case (from, control, s) =>
+      .unfoldAsync[(Long, FlowControl), Seq[DurableStateChange[A]]]((offset, Continue)) {
+        case (from, control) =>
           def retrieveNextBatch() = {
             for {
               queryUntil <- stateSequenceActor.ask(GetMaxGlobalOffset).mapTo[MaxGlobalOffset]
@@ -172,7 +171,7 @@ class JdbcDurableStateStore[A](
                 // Continue querying from the largest offset
                 xs.map(_.offset.value).max
               }
-              Some(((nextStartingOffset, nextControl, s :+ nextStartingOffset), xs))
+              Some(((nextStartingOffset, nextControl), xs))
             }
           }
 


### PR DESCRIPTION
Note this merge has a base branch that is the same commit as the v5.0.4 tag, _not_ main.

The changes remove a unused variable that is causing a memory leak in this class.

See [this Slack conversation](https://m1finance.slack.com/archives/C9GGG3ZNF/p1745590839151319) for details