### PR TITLE
Allow releasing to artifcatory locally

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -1,15 +1,13 @@
-import com.geirsson.CiReleasePlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerLicense, HeaderLicense }
 import sbt.Keys._
 import sbt._
 import sbt.plugins.JvmPlugin
-import xerial.sbt.Sonatype.autoImport.sonatypeProfileName
 
 object ProjectAutoPlugin extends AutoPlugin {
   object autoImport {}
 
-  override val requires = JvmPlugin && HeaderPlugin && CiReleasePlugin
+  override val requires = JvmPlugin && HeaderPlugin
 
   override def globalSettings =
     Seq(
@@ -81,8 +79,7 @@ object ProjectAutoPlugin extends AutoPlugin {
            |Copyright (C) 2019 - 2021 Lightbend Inc. <https://www.lightbend.com>
            |""".stripMargin)),
     resolvers += Resolver.typesafeRepo("releases"),
-    resolvers += Resolver.jcenterRepo,
-    sonatypeProfileName := "com.lightbend")
+    resolvers += Resolver.jcenterRepo)
 
   val disciplineScalacOptions = Set(
 //    "-Xfatal-warnings",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.18")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.6.0")
 
 // release
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.6")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.7")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 // docs
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.39")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,31 @@
+val ArtifactRepo = {
+  sys.env.get("ARTIFACTORY_REPO") match {
+    case Some(r) => "Artifactory-Releases".at(r)
+    case _       => sys.error(s"Required repo location not found at ${sys.env.get("ARTIFACTORY_REPO")}")
+  }
+}
+val SnapshotsRepo = {
+  sys.env.get("ARTIFACTORY_SNAPSHOT_REPO") match {
+    case Some(sr) => "Artifactory-Snapshots".at(s"$sr;build.timestamp=${java.time.Instant.now().toEpochMilli}")
+    case _        => sys.error(s"Required snapshot repo location not found at ${sys.env.get("ARTIFACTORY_SNAPSHOT_REPO")}")
+  }
+}
+
+(ThisBuild / publishTo) := Some(
+  // for full release use ArtifactRepo
+  // for snapshot release use SnapshotsRepo
+  SnapshotsRepo)
+
+// Sets credentials for Artifactory for all projects. Requires Env Vars or Credentials File
+(ThisBuild / credentials) += {
+  val credFilePath: File = sbt.io.Path.userHome / ".sbt" / ".credentials"
+
+  (sys.env.get("ARTIFACTORY_USER"), sys.env.get("ARTIFACTORY_API_KEY"), sys.env.get("ARTIFACTORY_REALM")) match {
+    case (Some(u), Some(k), Some(r)) => Credentials("Artifactory Realm", r, u, k)
+    case _ if credFilePath.exists()  => Credentials(credFilePath)
+    case _                           => sys.error(s"Required credentials not found in ENV VARS or $credFilePath")
+  }
+}
+
+// sets both Artifactory Repositories as new resolvers
+ThisBuild / resolvers ++= ArtifactRepo :: SnapshotsRepo :: Nil

--- a/publish.sbt
+++ b/publish.sbt
@@ -6,15 +6,19 @@ val ArtifactRepo = {
 }
 val SnapshotsRepo = {
   sys.env.get("ARTIFACTORY_SNAPSHOT_REPO") match {
-    case Some(sr) => "Artifactory-Snapshots".at(s"$sr;build.timestamp=${java.time.Instant.now().toEpochMilli}")
+    case Some(sr) => "Artifactory-Snapshots".at(sr)
     case _        => sys.error(s"Required snapshot repo location not found at ${sys.env.get("ARTIFACTORY_SNAPSHOT_REPO")}")
   }
 }
 
-(ThisBuild / publishTo) := Some(
-  // for full release use ArtifactRepo
-  // for snapshot release use SnapshotsRepo
-  SnapshotsRepo)
+val publishToEnv = sys.env.get("ARTIFACTORY_REPO_PUBLISH_TO")
+
+(ThisBuild / publishTo) := Some(publishToEnv.fold(SnapshotsRepo)(p =>
+  if (p == "SNAPSHOT") {
+    SnapshotsRepo
+  } else {
+    ArtifactRepo
+  }))
 
 // Sets credentials for Artifactory for all projects. Requires Env Vars or Credentials File
 (ThisBuild / credentials) += {

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,8 @@
 // For full release uncomment lines below and ensure proper version is designated
-//ThisBuild / version := "5.0.5"
-//ThisBuild / isSnapshot := false
+ThisBuild / version ~= { v =>
+  sys.env.get("ARTIFACTORY_REPO_PUBLISH_VERSION_PEKKO_PERSISTENCE_JDBC") match {
+    case Some(pv) => pv
+    case None     => v
+  }
+}
+ThisBuild / isSnapshot := !sys.env.get("ARTIFACTORY_REPO_PUBLISH_TO").contains("RELEASE")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,3 @@
+// For full release uncomment lines below and ensure proper version is designated
+//ThisBuild / version := "5.0.5"
+//ThisBuild / isSnapshot := false


### PR DESCRIPTION
Note the base for this PR is _not_ the main branch, it is a branch pointing to the v5.0.4 tag.

This disables the previous CI release plugin used by upstream and enables releasing to Artifactory as defined in environment variables and/or a credentials file.

See [this Slack conversation](https://m1finance.slack.com/archives/C9GGG3ZNF/p1745590839151319) for more details.